### PR TITLE
improving responsive global page

### DIFF
--- a/css/global_page.css
+++ b/css/global_page.css
@@ -1,46 +1,50 @@
 .map-container,
 .graph-container {
-    display: flex;
-    height: 300px;
+  display: flex;
+  height: 300px;
 }
 
 #graph {
-    display: flex;
-    order: 1;
-    height: inherit;
+  display: flex;
+  order: 1;
+  height: inherit;
 }
 
 .map-container:after,
 .clearfix {
-    display: flex;
-    content: '';
-    clear: both;
+  display: flex;
+  content: '';
+  clear: both;
 }
 
 @media only screen and (min-width: 576px) {
-    .map-container,
-    .graph-container {
-        height: 350px;
-    }
+  .map-container,
+  .graph-container {
+    height: 350px;
+  }
 }
 
 @media only screen and (min-width: 768px) {
-    .map-container,
-    .graph-container {
-        height: 400px;
-    }
+  .map-container,
+  .graph-container {
+    height: 400px;
+  }
 }
 
 @media only screen and (min-width: 992px) {
-    .map-container,
-    .graph-container {
-        height: 500px;
-    }
+  .map-container,
+  .graph-container {
+    height: 500px;
+    margin-bottom: 50px;
+  }
+  .onoffswitch {
+    margin-top: 25px;
+  }
 }
 
 @media only screen and (min-width: 1200px) {
-    .map-container,
-    .graph-container {
-        height: 600px;
-    }
+  .map-container,
+  .graph-container {
+    height: 600px;
+  }
 }


### PR DESCRIPTION
With this PR I am fixing the responsiveness of the "Global Page" for devices with viewports < 992px so that the text below the world map image can still be visible (see attachment below).

<img width="819" alt="Screenshot 2020-10-10 at 22 49 55" src="https://user-images.githubusercontent.com/21361479/95664790-54515080-0b4b-11eb-842f-648ba58ad4f2.png">

I also adjusted the overall CSS indentation.

If you find this PR helpful please mark it with a `hacktoberfest-accepted` label. Thank you! :) 