### PR TITLE
run covidtracer in docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM sebp/lighttpd:1.4.54-r0
+
+COPY *.html /var/www/localhost/htdocs/
+COPY css/ /var/www/localhost/htdocs/css/
+COPY js/ /var/www/localhost/htdocs/js/
+COPY utils/ /var/www/localhost/htdocs/utils/
+
+EXPOSE 80
+
+CMD ["start.sh"]

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # COVID-19 Tracer
 
-Source of the main site: 
+Source of the main site:
 ## https://covidtracer.netlify.com/
 ## https://mayurmadnani.github.io/covidtracer/
 
@@ -9,3 +9,15 @@ Data sources:
 * Global: [Data Repository by Johns Hopkins CSSE](https://github.com/CSSEGISandData/COVID-19)
 
 * India: [Ministry of Health and Family Welfare Government of India](https://www.mohfw.gov.in/)
+
+
+# Docker build
+You may build this site as a docker image with docker build
+```bash
+docker build . -t covidtracer
+```
+
+Run the docker image as a container
+```bash
+docker run -d -t -p 80:80 covidtracer:latest
+```


### PR DESCRIPTION
Hi,

I made some changes to enable covidtracer page to run in a docker container.

I am contributing Dockerfile to build covidtracer docker image, with that image you may run the image as docker container. I have incorporated instruction on how to do that in Readme.md. Check it out.

Thank you